### PR TITLE
Add aws_iam_role_policy_attachment resource

### DIFF
--- a/lib/terrafied/resource_shortcuts.rb
+++ b/lib/terrafied/resource_shortcuts.rb
@@ -393,6 +393,10 @@ class << self
     resource 'aws_iam_role', name,
              default_spec.deep_merge(spec)
   end
+  
+  def aws_iam_role_policy_attachment(name, spec={})
+    resource 'aws_iam_role_policy_attachment', name, spec
+  end
 
   def aws_iam_role_policy(name, spec={})
     default_spec = { name: name }


### PR DESCRIPTION
At the moment, terrafied doesn't have support for Terraform's [aws_iam_role_policy_attachment](https://www.terraform.io/docs/providers/aws/r/iam_role_policy_attachment.html) resource. This adds it!
